### PR TITLE
set overflow-wrap to `break-word` for all links 

### DIFF
--- a/src/_global.scss
+++ b/src/_global.scss
@@ -50,7 +50,7 @@ h2 {
 
 a {
   @include tr(color 0.6s, background-size 0.6s);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 
   &:hover {
     color: $font-color;


### PR DESCRIPTION
![Frame 1 (2)](https://user-images.githubusercontent.com/49285675/137880303-ee48f61f-3eb5-4fb2-980f-1f8e13f8c29d.png)
